### PR TITLE
clean: Remove unused fields from query

### DIFF
--- a/src/main/graphql/com/github/api/v4/ListProjectsQuery.graphql
+++ b/src/main/graphql/com/github/api/v4/ListProjectsQuery.graphql
@@ -16,10 +16,8 @@ query ListProjectsQuery($queryString: String!, $size: Int = 100, $page: String) 
                 url
                 sshUrl
                 isPrivate
-                description
                 viewerPermission
                 updatedAt
-                createdAt
             }
         }
         repositoryCount


### PR DESCRIPTION
These two fields are not used in RPS. Removing them could make the query slightly faster on Github side.