### PR TITLE
feature: Exclude archived repositories from list queries TAROT-3758

### DIFF
--- a/src/main/graphql/com/github/api/v4/ListOrganizationRepositoriesQuery.graphql
+++ b/src/main/graphql/com/github/api/v4/ListOrganizationRepositoriesQuery.graphql
@@ -8,6 +8,7 @@ query ListOrganizationRepositoriesQuery(
       first: $size
       after: $page
       orderBy: { field: PUSHED_AT, direction: DESC }
+      isArchived: false
     ) {
       nodes {
         ... on Repository {

--- a/src/main/graphql/com/github/api/v4/ListUserRepositoriesQuery.graphql
+++ b/src/main/graphql/com/github/api/v4/ListUserRepositoriesQuery.graphql
@@ -9,6 +9,7 @@ query ListUserRepositoriesQuery(
       after: $page
       affiliations: [ OWNER ]
       orderBy: { field: PUSHED_AT, direction: DESC }
+      isArchived: false
     ) {
       nodes {
         ... on Repository {

--- a/src/main/graphql/com/github/api/v4/OrganizationRepositoriesCountQuery.graphql
+++ b/src/main/graphql/com/github/api/v4/OrganizationRepositoriesCountQuery.graphql
@@ -2,7 +2,7 @@ query OrganizationRepositoriesCountQuery(
   $organizationName: String!
 ) {
   organization(login: $organizationName) {
-    repositories {
+    repositories(isArchived: false) {
       totalCount
     }
   }


### PR DESCRIPTION
## Summary
- Add `isArchived: false` to `ListOrganizationRepositoriesQuery` and `ListUserRepositoriesQuery` to filter out archived repos from results.

## Test plan
- [ ] Run query against real org/user with archived repos, confirm they're excluded.