### PR TITLE
Cross-compile to Scala 2.13

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,9 +2,10 @@ import java.nio.file.Files
 import sys.process._
 
 val scala212 = "2.12.20"
+val scala213 = "2.13.16"
 
 ThisBuild / scalaVersion := scala212
-ThisBuild / crossScalaVersions := Seq(scala212)
+ThisBuild / crossScalaVersions := Seq(scala212, scala213)
 
 name := "codacy-github-graphql"
 


### PR DESCRIPTION
## Summary
- Add Scala 2.13.16 to `crossScalaVersions` alongside 2.12.20, so `sbt +compile`/`+publish` build both.
- `apollo-runtime` dep is a plain Java artifact (`%`, not `%%`), so no cross-version lookup issue.

## Test plan
- [x] `sbt +compile` succeeds for both 2.12.20 and 2.13.16 locally.
- [x] CI already runs `sbt +compile` / `sbt +publish` (cross build), no workflow changes needed.